### PR TITLE
chore: fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![CI build status](https://github.com/DataKitchen/ngx-toolkit/actions/workflows/main.yml/badge.svg)
 
 
-Welcome to the DataKitchen `ngx-toolkit` monorepo! This repository houses a collection of libraries developed by our Front End team to address common tasks that Angular developers encounter on a daily basis. These libraries are split into <!-- three --> two npm packages:
+Welcome to the DataKitchen `ngx-toolkit` monorepo! This repository houses a collection of libraries developed by our Front End team to address common tasks that Angular developers encounter on a daily basis. These libraries are split into the following npm packages:
   - @datakitchen/ngx-toolkit
   > Provides solutions and best practices for implementing and synchronizing various features, including search inputs, pagination, and persistence using localStorage or query parameters. Also contains mocking utilities, a simplified version of Angular's typed reactive forms, and other small utilities that any Angular developer may need. See [ngx-toolkit's readme](https://github.com/DataKitchen/ngx-toolkit/blob/master/projects/core/README.md)
   - @datakitchen/ngx-monaco-editor


### PR DESCRIPTION
This updates the readme which was only mentioning two npm packages.